### PR TITLE
Fix parsing hexadecimal special chars with numbers

### DIFF
--- a/corpus/unicodes.txt
+++ b/corpus/unicodes.txt
@@ -614,3 +614,44 @@ Document with こんにちは
         (specialChar)
         (specialChar)
         (specialChar)))
+
+==============================================
+Document with special chars and numbers 你1337
+==============================================
+{\rtf1\ansi\ansicpg1252\cocoartf2638
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset134 PingFangSC-Regular;}
+{\colortbl;\red255\green255\blue255;\red15\green104\blue160;\red255\green255\blue255;}
+{\*\expandedcolortbl;;\csgenericrgb\c5882\c40784\c62745;\csgenericrgb\c100000\c100000\c100000;}
+\vieww18900\viewh8400\viewkind0
+\deftab593
+\pard\tx593\pardeftab593\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf2 \cb3 \'c4\'e31337}
+---------------------------------------------
+(document
+      (fonttbl
+        (fontinfo
+          (fontFamily)
+          (charset)
+          (fontname)))
+      (colortbl
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral))
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral))
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral)))
+      (parTbl)
+      (textUnit
+        (fontIndex)
+        (fontSize)
+        (colorFontIndex)
+        (specialChar)
+        (specialChar)
+        (textUnitContent)))

--- a/grammar.js
+++ b/grammar.js
@@ -398,7 +398,7 @@ module.exports = grammar({
     
     charset: () => /\d+/,
     unicode: () => /\d+/,
-    specialChar: () => /[0-9a-fA-F]+/,
+    specialChar: () => /[0-9a-fA-F]{1,2}/,
     fontIndex: $ => $._static_int_number_literal,
     fontSize: $ => $._static_int_number_literal,
     colorFontIndex: $ => $._static_int_number_literal,
@@ -423,6 +423,6 @@ module.exports = grammar({
     _static_PCDATA: $ => /[^\\\\}\\{;]+/,
 
   },
-});
+}); 
 
- 
+


### PR DESCRIPTION
### :tophat: What is the goal?

Fix a bug causing old RTF special chars `\'` followed by numbers to be parsed incorrectly. 

### :page_facing_up: How is it being implemented?

It was fixed by limiting the number of elements following the `\'` to `2`.

### :white_check_mark: How can it be tested?

Testing is automated 🤖 A new test case was added to the corpus.

 