### PR TITLE
Add support for matching all the ASCII printable chars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "parserOptions": { "ecmaVersion": "latest" },
   "env": { "es6": true },
   "rules": {
-    "no-undef": "off"
+    "no-undef": "off",
+    "no-useless-escape": "off"
   }
 }

--- a/corpus/main.txt
+++ b/corpus/main.txt
@@ -183,67 +183,39 @@ Minimal RTF document
     (colorFontIndex)
     (textUnitContent)))
 
+====================================================
+Matches all ASCCI printable characters as text units
+=====================================================
+{\rtf1\ansi\ansicpg1252\cocoartf2630
+\cocoatextscaling1\cocoaplatform1{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\sl-559\partightenfactor0
 
-=============================
-Text with '!' as special character
-=============================
-{\rtf1\ansi\ansicpg1252\cocoartf2638
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-
-\f0\fs24 \cf0 Hello World!}
-----------------------------
+\f0\fs48 \cf2  !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz|}
+-------------------------------
 (document
-  (fonttbl
-    (fontinfo
-      (fontFamily)
-      (charset)
-      (fontname)))
-  (colortbl
-    (colorvalue
-      (staticNumberLiteral)
-      (staticNumberLiteral)
-      (staticNumberLiteral)))
-  (parTbl)
-  (textUnit
-    (fontIndex)
-    (fontSize)
-    (colorFontIndex)
-    (textUnitContent)))
-
-
-=============================
-Text with '.' as special character
-=============================
-{\rtf1\ansi\ansicpg1252\cocoartf2638
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-
-\f0\fs24 \cf0 Hello World.}
-----------------------------
-(document
-  (fonttbl
-    (fontinfo
-      (fontFamily)
-      (charset)
-      (fontname)))
-  (colortbl
-    (colorvalue
-      (staticNumberLiteral)
-      (staticNumberLiteral)
-      (staticNumberLiteral)))
-  (parTbl)
-  (textUnit
-    (fontIndex)
-    (fontSize)
-    (colorFontIndex)
-    (textUnitContent)))
+      (fonttbl
+        (fontinfo
+          (fontFamily)
+          (charset)
+          (fontname)))
+      (colortbl
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral))
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral)))
+      (parTbl
+        (lineSpacing))
+      (textUnit
+        (fontIndex)
+        (fontSize)
+        (colorFontIndex)
+        (textUnitContent)))
 
 
 =============================

--- a/grammar.js
+++ b/grammar.js
@@ -91,7 +91,7 @@ module.exports = grammar({
 
     _nontaggedname: ($) => seq("{\\*", "\\fname", $._static_PCDATA, ";}"),
 
-    fontname: () => /[\w\s\-]+/, // eslint-disable-line
+    fontname: () => /[\w\s\-]+/,
     fonttypeface: ($) => $._static_PCDATA,
 
     _fontaltname: ($) => seq("{\\*", "\\falt", $._static_PCDATA, "}"),
@@ -366,7 +366,7 @@ module.exports = grammar({
 
     _commonTextUnitContent: () =>
       choice(
-        /[\w| |!|\.|:|\-|\t|\?|\*|^|@|,|/|\(|\)|<|>|;]+/, // eslint-disable-line
+        /[\w !\"`$&'\+=\~%\[\]\.:\-\t\?\*^@#,/\(\)<>;|`]+/,
         "\\\n",
         new RegExp("\\\\[" + ESCAPE_SET + "]"),
         // Chars that sholud be escaped but are not in RTF


### PR DESCRIPTION
### :tophat: What is the goal?

Add support for detecting as text all ASCII printable chars 

### :page_facing_up: How is it being implemented?

Added some missing characters to the __commonTextUnitContent regex

### :white_check_mark: How can it be tested?

Testing is automated 🤖 . 