### PR TITLE
Add support for font sizes in millimeters

### DIFF
--- a/corpus/fonts.txt
+++ b/corpus/fonts.txt
@@ -503,3 +503,41 @@ One line and different fonts
       (textUnit
         (fontIndex)
         (textUnitContent)))
+
+
+===================================
+Supports font size in millimeters
+===================================
+{\rtf1\ansi\ansicpg1252\cocoartf2630
+\cocoatextscaling1\cocoaplatform1{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;}
+{\colortbl;\red255\green255\blue255;\red17\green17\blue17;}
+{\*\expandedcolortbl;;\cssrgb\c6667\c6667\c6667;}
+\deftab720
+\pard\pardeftab720\qc\partightenfactor0
+
+\f0\b\fs64\fsmilli32400 \cf2 Millis font size}
+---------------------------
+(document
+  (fonttbl
+     (fontinfo
+       (fontFamily)
+       (charset)
+       (fontname)))
+   (colortbl
+     (colorvalue
+       (staticNumberLiteral)
+       (staticNumberLiteral)
+       (staticNumberLiteral))
+     (colorvalue
+       (staticNumberLiteral)
+       (staticNumberLiteral)
+       (staticNumberLiteral)))
+   (parTbl
+     (alignmentConfig))
+   (textUnit
+     (fontIndex)
+     (boldEnabled)
+     (fontSize)
+     (fontSizeMillimeters)
+     (colorFontIndex)
+     (textUnitContent)))

--- a/grammar.js
+++ b/grammar.js
@@ -339,6 +339,7 @@ module.exports = grammar({
       choice(
         seq("\\f", field("fontIndex", $.fontIndex)),
         seq("\\fs", field("fontSize", $.fontSize)),
+        seq("\\fsmilli", field("fontSizeMillimeters", $.fontSizeMillimeters)),
         seq("\\cf", field("colorFontIndex", $.colorFontIndex)),
         $.boldEnabled,
         $.boldDisabled,
@@ -387,6 +388,7 @@ module.exports = grammar({
     specialChar: () => /[0-9a-fA-F]{1,2}/,
     fontIndex: ($) => $._static_int_number_literal,
     fontSize: ($) => $._static_int_number_literal,
+    fontSizeMillimeters: ($) => $._static_int_number_literal,
     colorFontIndex: ($) => $._static_int_number_literal,
     boldEnabled: () => "\\b",
     boldDisabled: () => /\\b0/,


### PR DESCRIPTION
### :tophat: What is the goal?

Add support for font sizes in millimeters

### :page_facing_up: How is it being implemented?

Implemented the `\fsmilliN` control word

### :white_check_mark: How can it be tested?

Testing is automated 🤖 