### PR TITLE
Detect the text unit where the hyperlink is set

### DIFF
--- a/corpus/hyperlink.txt
+++ b/corpus/hyperlink.txt
@@ -24,11 +24,13 @@ Adios}
           (staticNumberLiteral)
           (staticNumberLiteral)))
       (parTbl)
+      (hyperlink)
       (textUnit
         (fontIndex)
         (fontSize)
         (colorFontIndex)
         (textUnitContent))
+      (endHyperlink)
       (textUnit
         (fontIndex)
         (fontSize)
@@ -72,11 +74,13 @@ Text with hpyerlink - https://www.google.com/
         (textUnitContent))
       (textUnit
         (textUnitContent))
+      (hyperlink)
       (textUnit
         (fontIndex)
         (fontSize)
         (colorFontIndex)
-        (textUnitContent)))
+        (textUnitContent))
+      (endHyperlink))
 
 
 =============================
@@ -115,8 +119,10 @@ Text with hpyerlink - No extra style
         (textUnitContent))
       (textUnit
         (textUnitContent))
+      (hyperlink)
       (textUnit
-        (textUnitContent)))
+        (textUnitContent))
+      (endHyperlink))
 
 
 =============================
@@ -155,9 +161,11 @@ test.\
         (fontSize)
         (colorFontIndex)
         (textUnitContent))
+      (hyperlink)
       (textUnit
         (fontSize)
         (textUnitContent))
+      (endHyperlink)
       (textUnit
         (textUnitContent))
       (textUnit
@@ -201,7 +209,9 @@ Text with hpyerlink - No extra style and HTTP://GOGOLE.COM
         (textUnitContent))
       (textUnit
         (textUnitContent))
+      (hyperlink)
       (textUnit
         (textUnitContent))
+      (endHyperlink)
       (textUnit
         (textUnitContent)))

--- a/corpus/hyperlink.txt
+++ b/corpus/hyperlink.txt
@@ -215,3 +215,52 @@ Text with hpyerlink - No extra style and HTTP://GOGOLE.COM
       (endHyperlink)
       (textUnit
         (textUnitContent)))
+
+
+=============================
+Text with hpyerlink composed by 2 text units
+=============================
+{\rtf1\ansi\ansicpg1252\cocoartf2639
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 Helvetica-Bold;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+\paperw11900\paperh16840\margl1440\margr1440\vieww11520\viewh8400\viewkind0
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf2 This is a {\field{\*\fldinst{HYPERLINK "http://www.google.com"}}{\fldrslt strange 
+\f1\b\fs36 hyperlink}}}
+----------------------------
+    (document
+      (fonttbl
+        (fontinfo
+          (fontFamily)
+          (charset)
+          (fontname))
+        (fontinfo
+          (fontFamily)
+          (charset)
+          (fontname)))
+      (colortbl
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral))
+        (colorvalue
+          (staticNumberLiteral)
+          (staticNumberLiteral)
+          (staticNumberLiteral)))
+      (parTbl)
+      (textUnit
+        (fontIndex)
+        (fontSize)
+        (colorFontIndex)
+        (textUnitContent))
+      (hyperlink)
+      (textUnit
+        (textUnitContent))
+      (textUnit
+        (fontIndex)
+        (boldEnabled)
+        (fontSize)
+        (textUnitContent))
+      (endHyperlink))

--- a/grammar.js
+++ b/grammar.js
@@ -295,7 +295,8 @@ module.exports = grammar({
 
     _fieldinst: ($) => seq("{\\*", "\\fldinst", $._hyperlinkUnit, "}"),
 
-    _fieldslt: ($) => seq("{\\fldrslt", " ", $.textUnit, $.endHyperlink),
+    _fieldslt: ($) =>
+      seq("{\\fldrslt", " ", repeat1($.textUnit), $.endHyperlink),
 
     endHyperlink: () => "}",
 
@@ -314,7 +315,7 @@ module.exports = grammar({
       seq($._textUnitVisibleInformation, optional("\n")),
 
     hyperlink: ($) => $._static_URL_literal,
-    
+
     textUnit: ($) =>
       seq(optional($._textUnitParameters), $._textUnitInformation),
 

--- a/grammar.js
+++ b/grammar.js
@@ -295,9 +295,11 @@ module.exports = grammar({
 
     _fieldinst: ($) => seq("{\\*", "\\fldinst", $._hyperlinkUnit, "}"),
 
-    _fieldslt: ($) => seq("{\\fldrslt", " ", $.textUnit, "}"),
+    _fieldslt: ($) => seq("{\\fldrslt", " ", $.textUnit, $.endHyperlink),
 
-    _hyperlinkUnit: ($) => seq('{HYPERLINK "', $._static_URL_literal, '"}'),
+    endHyperlink: () => "}",
+
+    _hyperlinkUnit: ($) => seq('{HYPERLINK "', $.hyperlink, '"}'),
 
     _textUnitParameters: ($) =>
       seq(repeat1(seq(repeat1($._textUnit_config), " "))),
@@ -311,6 +313,8 @@ module.exports = grammar({
     _textUnitInformation: ($) =>
       seq($._textUnitVisibleInformation, optional("\n")),
 
+    hyperlink: ($) => $._static_URL_literal,
+    
     textUnit: ($) =>
       seq(optional($._textUnitParameters), $._textUnitInformation),
 


### PR DESCRIPTION
### :tophat: What is the goal?

Detect the text unit where the hyperlink is set

### :page_facing_up: How is it being implemented?

Generating a key for the `hyperlink` and another one for the end of the `endHyperlink`

### :white_check_mark: How can it be tested?

We are created specific Unit Tests for covering these scenarios
