### PR TITLE
Add `clean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/GoodNotes/GoodNotes-5",
   "private": true,
   "scripts": {
+    "clean": "rm -rf src/grammar.json src/node-types.json src/parser.c src/tree_sitter log.html .swift build public coverage",
     "generate": "tree-sitter generate --no-bindings",
     "test": "tree-sitter test",
     "lint": "eslint grammar.js && prettier --check grammar.js",


### PR DESCRIPTION
### :tophat: What is the goal?

Allow cleaning the build artifacts. Also allow running `clean` script in Yarn workspaces that include this package.

### :page_facing_up: How is it being implemented?

Just a call to `rm -rf` passing the list of `postinstall` artifacts explicitly excluded from the repository in the `.gitignore`. file.

### :white_check_mark: How can it be tested?

1. Install this package.
2. Ensure `yarn postinstall` has been executed
3. Notice the contents of `src` folder
4. Run `yarn clean`
5. Notice the contents of `src` folder, there will be fewer files. Also notice that `git status` will tell you there are no changes
